### PR TITLE
feat(storage): updating to cairo 2.1.0

### DIFF
--- a/alexandria/storage/README.md
+++ b/alexandria/storage/README.md
@@ -35,35 +35,12 @@ Note that unlike `get`, using this bracket notation panics when accessing an out
 
 ### Support for custom types
 
-`List` supports most of the corelib types out of the box. However if you have a custom type that you'd like to store in a `List`, you will have to implement the `StorageSize` trait. It's a simple trait, just one function `storage_size` returning the number of storage slots necessary for your type.
-
-Let's look at an example:
-
-```rust
-use alexandria::storage::StorageSize;
-
-#[derive(starknet::StorageAccess)]
-struct Dimensions {
-    width: u128,
-    height: u128,
-    depth: u128
-}
-
-impl DimensionsStorageSize of StorageSize<Dimensions> {
-    fn storage_size() -> u8 {
-        3
-    }
-}
-```
-
-To save the `Dimensions` struct into storage, we need 3 storage slots for each of its members, as returned from the `storage_size` function.
-
-Note that for obvious reasons, any type you want to store in a `List` also has to implement the `StorageAccess` trait, hence the `#[derive(starknet::StorageAccess)]
-` above.
+`List` supports most of the corelib types out of the box. If you want to store a your own custom type in a `List`, it has to implement the `Store` trait. You can have the compiler derive it for you using the `#[derive(starknet::Store)]` attribute.
 
 ### Caveats
 
 There are two idiosyncacies you should be aware of when using `List`
+
 1. The `append` operation costs 2 storage writes - one for the value itself and another one for updating the List's length
 2. Due to a compiler limitation, it is not possible to use mutating operations with a single inline statement. For example, `self.amounts.read().append(42);` will not work. You have to do it in 2 steps:
 

--- a/alexandria/storage/Scarb.toml
+++ b/alexandria/storage/Scarb.toml
@@ -1,5 +1,10 @@
 [package]
 name = "alexandria_storage"
-version = "0.1.0"
+version = "0.2.0"
 description = "Starknet storage utilities"
 homepage = "https://github.com/keep-starknet-strange/alexandria/tree/main/storage"
+
+[[target.starknet-contract]]
+
+[dependencies]
+starknet = ">=2.1.0"

--- a/alexandria/storage/src/list.cairo
+++ b/alexandria/storage/src/list.cairo
@@ -1,10 +1,10 @@
-use hash::LegacyHash;
+use array::ArrayTrait;
 use integer::U32DivRem;
 use option::OptionTrait;
-use array::ArrayTrait;
+use poseidon::poseidon_hash_span;
 use starknet::{storage_read_syscall, storage_write_syscall, SyscallResult, SyscallResultTrait};
 use starknet::storage_access::{
-    StorageAccess, StorageBaseAddress, storage_address_to_felt252, storage_address_from_base,
+    Store, StorageBaseAddress, storage_address_to_felt252, storage_address_from_base,
     storage_address_from_base_and_offset, storage_base_address_from_felt252
 };
 use traits::{Default, DivRem, IndexView, Into, TryInto};
@@ -29,36 +29,9 @@ trait ListTrait<T> {
     fn array(self: @List<T>) -> Array<T>;
 }
 
-// when writing elements in storage, we need to know how many storage slots
-// they take up to properly calculate the offset into a storage segment
-// that's what this trait provides
-// it's very similar to the `size_internal` function in StorageAccess trait
-// with one crutial difference - this function does not need a T element
-// to return the size of the T element!
-trait StorageSize<T> {
-    fn storage_size() -> u8;
-}
-
-// any type that can Into to felt252 has a size of 1
-impl StorageSizeFelt252<T, impl TInto: Into<T, felt252>> of StorageSize<T> {
-    fn storage_size() -> u8 {
-        1
-    }
-}
-
-// u256 needs 2 storage slots
-impl StorageSizeU256 of StorageSize<u256> {
-    fn storage_size() -> u8 {
-        2
-    }
-}
 
 impl ListImpl<
-    T,
-    impl TCopy: Copy<T>,
-    impl TDrop: Drop<T>,
-    impl TStorageAccess: StorageAccess<T>,
-    impl TStorageSize: StorageSize<T>
+    T, impl TCopy: Copy<T>, impl TDrop: Drop<T>, impl TStore: Store<T>, 
 > of ListTrait<T> {
     fn len(self: @List<T>) -> u32 {
         *self.len
@@ -72,12 +45,11 @@ impl ListImpl<
         let (base, offset) = calculate_base_and_offset_for_index(
             self.base, self.len, self.storage_size
         );
-        StorageAccess::write_at_offset_internal(self.address_domain, base, offset, value)
-            .unwrap_syscall();
+        Store::write_at_offset(self.address_domain, base, offset, value).unwrap_syscall();
 
         let append_at = self.len;
         self.len += 1;
-        StorageAccess::write(self.address_domain, self.base, self.len);
+        Store::write(self.address_domain, self.base, self.len);
 
         append_at
     }
@@ -90,8 +62,7 @@ impl ListImpl<
         let (base, offset) = calculate_base_and_offset_for_index(
             *self.base, index, *self.storage_size
         );
-        let t = StorageAccess::read_at_offset_internal(*self.address_domain, base, offset)
-            .unwrap_syscall();
+        let t = Store::read_at_offset(*self.address_domain, base, offset).unwrap_syscall();
         Option::Some(t)
     }
 
@@ -100,8 +71,7 @@ impl ListImpl<
         let (base, offset) = calculate_base_and_offset_for_index(
             self.base, index, self.storage_size
         );
-        StorageAccess::write_at_offset_internal(self.address_domain, base, offset, value)
-            .unwrap_syscall();
+        Store::write_at_offset(self.address_domain, base, offset, value).unwrap_syscall();
     }
 
     fn pop_front(ref self: List<T>) -> Option<T> {
@@ -114,7 +84,7 @@ impl ListImpl<
         // only decrementing the len - makes it unaccessible through
         // the interfaces, next append will overwrite the values
         self.len -= 1;
-        StorageAccess::write(self.address_domain, self.base, self.len);
+        Store::write(self.address_domain, self.base, self.len);
 
         popped
     }
@@ -134,11 +104,7 @@ impl ListImpl<
 }
 
 impl AListIndexViewImpl<
-    T,
-    impl TCopy: Copy<T>,
-    impl TDrop: Drop<T>,
-    impl TStorageAccess: StorageAccess<T>,
-    impl TStorageSize: StorageSize<T>
+    T, impl TCopy: Copy<T>, impl TDrop: Drop<T>, impl TStore: Store<T>, 
 > of IndexView<List<T>, u32, T> {
     fn index(self: @List<T>, index: u32) -> T {
         self.get(index).expect('List index out of bounds')
@@ -183,41 +149,45 @@ fn calculate_base_and_offset_for_index(
 ) -> (StorageBaseAddress, u8) {
     let max_elements = POW2_8 / storage_size.into();
     let (key, offset) = U32DivRem::div_rem(index, max_elements.try_into().unwrap());
-
-    let segment_base = storage_base_address_from_felt252(
-        LegacyHash::hash(storage_address_to_felt252(storage_address_from_base(list_base)), key)
-    );
+    // hash the base address and the key which is the segment number
+    let addr_elements = array![
+        storage_address_to_felt252(storage_address_from_base(list_base)), key.into()
+    ];
+    let segment_base = storage_base_address_from_felt252(poseidon_hash_span(addr_elements.span()));
 
     (segment_base, offset.try_into().unwrap() * storage_size)
 }
 
-impl ListStorageAccess<T, impl TStorageSize: StorageSize<T>> of StorageAccess<List<T>> {
+impl ListStore<T, impl TStore: Store<T>> of Store<List<T>> {
     fn read(address_domain: u32, base: StorageBaseAddress) -> SyscallResult<List<T>> {
-        let len: u32 = StorageAccess::read(address_domain, base).unwrap_syscall();
-        let storage_size: u8 = StorageSize::<T>::storage_size();
+        let len: u32 = Store::read(address_domain, base).unwrap_syscall();
+        let storage_size: u8 = Store::<T>::size();
         Result::Ok(List { address_domain, base, len, storage_size })
     }
 
+    #[inline(always)]
     fn write(address_domain: u32, base: StorageBaseAddress, value: List<T>) -> SyscallResult<()> {
-        StorageAccess::write(address_domain, base, value.len)
+        Store::write(address_domain, base, value.len)
     }
 
-    fn read_at_offset_internal(
+    fn read_at_offset(
         address_domain: u32, base: StorageBaseAddress, offset: u8
     ) -> SyscallResult<List<T>> {
-        let len: u32 = StorageAccess::read_at_offset_internal(address_domain, base, offset)
-            .unwrap_syscall();
-        let storage_size: u8 = StorageSize::<T>::storage_size();
+        let len: u32 = Store::read_at_offset(address_domain, base, offset).unwrap_syscall();
+        let storage_size: u8 = Store::<T>::size();
         Result::Ok(List { address_domain, base, len, storage_size })
     }
 
-    fn write_at_offset_internal(
+    #[inline(always)]
+    fn write_at_offset(
         address_domain: u32, base: StorageBaseAddress, offset: u8, value: List<T>
     ) -> SyscallResult<()> {
-        StorageAccess::write_at_offset_internal(address_domain, base, offset, value.len)
+        Store::write_at_offset(address_domain, base, offset, value.len)
     }
 
-    fn size_internal(value: List<T>) -> u8 {
-        StorageAccess::size_internal(value.len)
+    #[inline(always)]
+    fn size() -> u8 {
+        // we're only storing `len`, an u8
+        Store::<u8>::size()
     }
 }

--- a/alexandria/storage/src/tests/list_test.cairo
+++ b/alexandria/storage/src/tests/list_test.cairo
@@ -25,7 +25,7 @@ mod AListHolder {
 
     #[storage]
     struct Storage {
-        // to test a corelib type that has StorageAccess and
+        // to test a corelib type that has Store and
         // Into<ContractAddress, felt252>
         addrs: List<ContractAddress>,
         // to test a corelib compound struct
@@ -91,22 +91,6 @@ mod tests {
 
     use super::{AListHolder, IAListHolderDispatcher, IAListHolderDispatcherTrait};
 
-    // so that we're able to compare 2-tuples in the test code
-    impl TupleSize2PartialEq<
-        E0, E1, impl E0PartialEq: PartialEq<E0>, impl E1PartialEq: PartialEq<E1>
-    > of PartialEq<(E0, E1)> {
-        #[inline(always)]
-        fn eq(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
-            let (lhs0, lhs1) = lhs;
-            let (rhs0, rhs1) = rhs;
-            (lhs0 == rhs0) & (lhs1 == rhs1)
-        }
-        #[inline(always)]
-        fn ne(lhs: @(E0, E1), rhs: @(E0, E1)) -> bool {
-            !(rhs == lhs)
-        }
-    }
-
     fn deploy_mock() -> IAListHolderDispatcher {
         let class_hash: ClassHash = AListHolder::TEST_CLASS_HASH.try_into().unwrap();
         let ctor_data: Array<felt252> = Default::default();
@@ -152,7 +136,7 @@ mod tests {
         let mock_addr = mock_addr();
 
         let mut index: u32 = 0;
-        let max: u32 = 1025;
+        let max: u32 = 513;
 
         // test appending many
         loop {


### PR DESCRIPTION
Updating `List` to Cairo v2.1.0.

Summary of updates:

* using the new `Store` trait
* removing List's `StorageSize` trait in favor of `Store::size`
* replacing the Pedersen hashing function (`LegacyHash`) with Poseidon (10x cheaper)
* shortening the `test_append_get_many` test case by approximately half